### PR TITLE
[Feat]: 일정 API 연동 및 상태관리 구현 (#10)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ dist-ssr
 *.sln
 *.sw?
 .env
+
+### VibeCoding Documentation ###
+ShnDocs/

--- a/src/hooks/schedule/useSchedule.js
+++ b/src/hooks/schedule/useSchedule.js
@@ -1,19 +1,69 @@
+/**
+ * @fileoverview 일정 관리 커스텀 훅 모듈
+ * @description React 커스텀 훅을 통한 일정 CRUD 로직 및 상태 관리 제공
+ * @author 신동준
+ * @since 2025-09-17
+ * @version 1.0.0
+ */
+
 import { useState, useCallback } from 'react';
 import { scheduleApi, scheduleUtils } from '../../services/scheduleApi.js';
 
-// 일정 관리 커스텀 훅
+/**
+ * @description 일정 관리를 위한 커스텀 훅
+ * @author 신동준
+ * @since 2025-09-17
+ *
+ * 주요 기능:
+ * - 일정 CRUD 작업 (생성, 조회, 수정, 삭제)
+ * - 일정 완료/미완료 상태 토글
+ * - 월별/날짜별 일정 조회
+ * - 로딩 및 에러 상태 관리
+ * - FullCalendar 이벤트 형식 변환
+ *
+ * @returns {Object} 일정 관리 관련 상태 및 함수들
+ */
 export const useSchedule = () => {
+  /**
+   * @description 일정 목록 상태
+   * @type {Array<Object>}
+   */
   const [schedules, setSchedules] = useState([]);
+
+  /**
+   * @description 현재 선택된 일정 상태
+   * @type {Object|null}
+   */
   const [selectedSchedule, setSelectedSchedule] = useState(null);
+
+  /**
+   * @description 로딩 상태
+   * @type {boolean}
+   */
   const [loading, setLoading] = useState(false);
+
+  /**
+   * @description 에러 상태
+   * @type {string|null}
+   */
   const [error, setError] = useState(null);
 
-  // 에러 초기화
+  /**
+   * @description 에러 상태 초기화 함수
+   * @author 신동준
+   * @since 2025-09-17
+   */
   const clearError = useCallback(() => {
     setError(null);
   }, []);
 
-  // 로딩 상태 관리
+  /**
+   * @description 비동기 작업에 로딩 상태 관리를 적용하는 고차 함수
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {Function} asyncFunction - 실행할 비동기 함수
+   * @returns {Promise} 비동기 함수 실행 결과
+   */
   const withLoading = useCallback(async (asyncFunction) => {
     setLoading(true);
     setError(null);
@@ -28,7 +78,14 @@ export const useSchedule = () => {
     }
   }, []);
 
-  // 새 일정 생성
+  /**
+   * @description 새 일정 생성 함수
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {Object} scheduleData - 생성할 일정 데이터
+   * @returns {Promise<Object>} 생성된 일정 데이터
+   * @throws {Error} 유효성 검증 실패 또는 API 호출 실패 시
+   */
   const createSchedule = useCallback(async (scheduleData) => {
     return withLoading(async () => {
       const validation = scheduleUtils.validateScheduleData(scheduleData);
@@ -42,7 +99,13 @@ export const useSchedule = () => {
     });
   }, [withLoading]);
 
-  // 일정 조회
+  /**
+   * @description 특정 일정 조회 함수
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {number} scheduleId - 조회할 일정 ID
+   * @returns {Promise<Object>} 조회된 일정 데이터
+   */
   const fetchSchedule = useCallback(async (scheduleId) => {
     return withLoading(async () => {
       const schedule = await scheduleApi.getById(scheduleId);
@@ -51,7 +114,15 @@ export const useSchedule = () => {
     });
   }, [withLoading]);
 
-  // 일정 수정
+  /**
+   * @description 일정 수정 함수
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {number} scheduleId - 수정할 일정 ID
+   * @param {Object} scheduleData - 수정할 일정 데이터
+   * @returns {Promise<Object>} 수정된 일정 데이터
+   * @throws {Error} 유효성 검증 실패 또는 API 호출 실패 시
+   */
   const updateSchedule = useCallback(async (scheduleId, scheduleData) => {
     return withLoading(async () => {
       const validation = scheduleUtils.validateScheduleData(scheduleData);
@@ -70,7 +141,13 @@ export const useSchedule = () => {
     });
   }, [withLoading]);
 
-  // 일정 삭제
+  /**
+   * @description 일정 삭제 함수
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {number} scheduleId - 삭제할 일정 ID
+   * @returns {Promise<void>}
+   */
   const deleteSchedule = useCallback(async (scheduleId) => {
     return withLoading(async () => {
       await scheduleApi.delete(scheduleId);
@@ -81,7 +158,14 @@ export const useSchedule = () => {
     });
   }, [withLoading, selectedSchedule]);
 
-  // 일정 완료/미완료 토글
+  /**
+   * @description 일정 완료/미완료 상태 토글 함수
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {number} scheduleId - 상태를 변경할 일정 ID
+   * @param {boolean} isCompleted - 완료 상태 (true: 완료, false: 미완료)
+   * @returns {Promise<Object>} 업데이트된 일정 데이터
+   */
   const toggleScheduleComplete = useCallback(async (scheduleId, isCompleted) => {
     return withLoading(async () => {
       const updatedSchedule = await scheduleApi.toggleComplete(scheduleId, isCompleted);
@@ -97,7 +181,14 @@ export const useSchedule = () => {
     });
   }, [withLoading, selectedSchedule]);
 
-  // 월별 일정 조회
+  /**
+   * @description 월별 일정 조회 함수
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {number} year - 조회할 연도
+   * @param {number} month - 조회할 월 (1-12)
+   * @returns {Promise<Array>} 해당 월의 일정 배열
+   */
   const fetchSchedulesByMonth = useCallback(async (year, month) => {
     return withLoading(async () => {
       const monthSchedules = await scheduleApi.getByMonth(year, month);
@@ -106,7 +197,13 @@ export const useSchedule = () => {
     });
   }, [withLoading]);
 
-  // 특정 날짜 일정 조회
+  /**
+   * @description 특정 날짜 일정 조회 함수
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {string} date - 조회할 날짜 (YYYY-MM-DD 형식)
+   * @returns {Promise<Array>} 해당 날짜의 일정 배열
+   */
   const fetchSchedulesByDate = useCallback(async (date) => {
     return withLoading(async () => {
       const dateSchedules = await scheduleApi.getByDate(date);
@@ -114,16 +211,47 @@ export const useSchedule = () => {
     });
   }, [withLoading]);
 
-  // FullCalendar 이벤트 형식으로 변환
+  /**
+   * @description 현재 일정 목록을 FullCalendar 이벤트 형식으로 변환
+   * @author 신동준
+   * @since 2025-09-17
+   * @returns {Array} FullCalendar 이벤트 객체 배열
+   */
   const getFullCalendarEvents = useCallback(() => {
     return scheduleUtils.toFullCalendarEvents(schedules);
   }, [schedules]);
 
-  // 선택된 일정 초기화
+  /**
+   * @description 선택된 일정 초기화 함수
+   * @author 신동준
+   * @since 2025-09-17
+   */
   const clearSelectedSchedule = useCallback(() => {
     setSelectedSchedule(null);
   }, []);
 
+  /**
+   * @description 훅에서 반환하는 객체
+   * @author 신동준
+   * @since 2025-09-17
+   *
+   * @returns {Object} 일정 관리 관련 상태 및 함수들
+   * @returns {Array} returns.schedules - 일정 목록
+   * @returns {Object|null} returns.selectedSchedule - 선택된 일정
+   * @returns {boolean} returns.loading - 로딩 상태
+   * @returns {string|null} returns.error - 에러 메시지
+   * @returns {Function} returns.createSchedule - 일정 생성 함수
+   * @returns {Function} returns.fetchSchedule - 일정 조회 함수
+   * @returns {Function} returns.updateSchedule - 일정 수정 함수
+   * @returns {Function} returns.deleteSchedule - 일정 삭제 함수
+   * @returns {Function} returns.toggleScheduleComplete - 완료 상태 토글 함수
+   * @returns {Function} returns.fetchSchedulesByMonth - 월별 일정 조회 함수
+   * @returns {Function} returns.fetchSchedulesByDate - 날짜별 일정 조회 함수
+   * @returns {Function} returns.getFullCalendarEvents - FullCalendar 이벤트 변환 함수
+   * @returns {Function} returns.clearSelectedSchedule - 선택된 일정 초기화 함수
+   * @returns {Function} returns.clearError - 에러 초기화 함수
+   * @returns {Object} returns.utils - 일정 유틸리티 함수들
+   */
   return {
     // 상태
     schedules,

--- a/src/hooks/schedule/useSchedule.js
+++ b/src/hooks/schedule/useSchedule.js
@@ -1,0 +1,149 @@
+import { useState, useCallback } from 'react';
+import { scheduleApi, scheduleUtils } from '../../services/scheduleApi.js';
+
+// 일정 관리 커스텀 훅
+export const useSchedule = () => {
+  const [schedules, setSchedules] = useState([]);
+  const [selectedSchedule, setSelectedSchedule] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+
+  // 에러 초기화
+  const clearError = useCallback(() => {
+    setError(null);
+  }, []);
+
+  // 로딩 상태 관리
+  const withLoading = useCallback(async (asyncFunction) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await asyncFunction();
+      return result;
+    } catch (err) {
+      setError(err.response?.data?.message || err.message || '오류가 발생했습니다.');
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // 새 일정 생성
+  const createSchedule = useCallback(async (scheduleData) => {
+    return withLoading(async () => {
+      const validation = scheduleUtils.validateScheduleData(scheduleData);
+      if (!validation.isValid) {
+        throw new Error(Object.values(validation.errors)[0]);
+      }
+
+      const newSchedule = await scheduleApi.create(scheduleData);
+      setSchedules(prev => [...prev, newSchedule]);
+      return newSchedule;
+    });
+  }, [withLoading]);
+
+  // 일정 조회
+  const fetchSchedule = useCallback(async (scheduleId) => {
+    return withLoading(async () => {
+      const schedule = await scheduleApi.getById(scheduleId);
+      setSelectedSchedule(schedule);
+      return schedule;
+    });
+  }, [withLoading]);
+
+  // 일정 수정
+  const updateSchedule = useCallback(async (scheduleId, scheduleData) => {
+    return withLoading(async () => {
+      const validation = scheduleUtils.validateScheduleData(scheduleData);
+      if (!validation.isValid) {
+        throw new Error(Object.values(validation.errors)[0]);
+      }
+
+      const updatedSchedule = await scheduleApi.update(scheduleId, scheduleData);
+      setSchedules(prev =>
+        prev.map(schedule =>
+          schedule.scheduleId === scheduleId ? updatedSchedule : schedule
+        )
+      );
+      setSelectedSchedule(updatedSchedule);
+      return updatedSchedule;
+    });
+  }, [withLoading]);
+
+  // 일정 삭제
+  const deleteSchedule = useCallback(async (scheduleId) => {
+    return withLoading(async () => {
+      await scheduleApi.delete(scheduleId);
+      setSchedules(prev => prev.filter(schedule => schedule.scheduleId !== scheduleId));
+      if (selectedSchedule?.scheduleId === scheduleId) {
+        setSelectedSchedule(null);
+      }
+    });
+  }, [withLoading, selectedSchedule]);
+
+  // 일정 완료/미완료 토글
+  const toggleScheduleComplete = useCallback(async (scheduleId, isCompleted) => {
+    return withLoading(async () => {
+      const updatedSchedule = await scheduleApi.toggleComplete(scheduleId, isCompleted);
+      setSchedules(prev =>
+        prev.map(schedule =>
+          schedule.scheduleId === scheduleId ? updatedSchedule : schedule
+        )
+      );
+      if (selectedSchedule?.scheduleId === scheduleId) {
+        setSelectedSchedule(updatedSchedule);
+      }
+      return updatedSchedule;
+    });
+  }, [withLoading, selectedSchedule]);
+
+  // 월별 일정 조회
+  const fetchSchedulesByMonth = useCallback(async (year, month) => {
+    return withLoading(async () => {
+      const monthSchedules = await scheduleApi.getByMonth(year, month);
+      setSchedules(monthSchedules);
+      return monthSchedules;
+    });
+  }, [withLoading]);
+
+  // 특정 날짜 일정 조회
+  const fetchSchedulesByDate = useCallback(async (date) => {
+    return withLoading(async () => {
+      const dateSchedules = await scheduleApi.getByDate(date);
+      return dateSchedules;
+    });
+  }, [withLoading]);
+
+  // FullCalendar 이벤트 형식으로 변환
+  const getFullCalendarEvents = useCallback(() => {
+    return scheduleUtils.toFullCalendarEvents(schedules);
+  }, [schedules]);
+
+  // 선택된 일정 초기화
+  const clearSelectedSchedule = useCallback(() => {
+    setSelectedSchedule(null);
+  }, []);
+
+  return {
+    // 상태
+    schedules,
+    selectedSchedule,
+    loading,
+    error,
+
+    // 액션
+    createSchedule,
+    fetchSchedule,
+    updateSchedule,
+    deleteSchedule,
+    toggleScheduleComplete,
+    fetchSchedulesByMonth,
+    fetchSchedulesByDate,
+    getFullCalendarEvents,
+    clearSelectedSchedule,
+    clearError,
+
+    // 유틸리티
+    utils: scheduleUtils,
+  };
+};

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,0 +1,79 @@
+import axios from 'axios';
+
+// API 기본 설정
+const API_BASE_URL = 'http://localhost:9005/api';
+
+// Axios 인스턴스 생성
+const apiClient = axios.create({
+  baseURL: API_BASE_URL,
+  timeout: 10000,
+  withCredentials: true, // JWT 쿠키 전달을 위해 필요
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+// 요청 인터셉터
+apiClient.interceptors.request.use(
+  (config) => {
+    // 요청 전 처리 (로딩 상태 등)
+    console.log(`[API Request] ${config.method?.toUpperCase()} ${config.url}`);
+    return config;
+  },
+  (error) => {
+    console.error('[API Request Error]', error);
+    return Promise.reject(error);
+  }
+);
+
+// 응답 인터셉터
+apiClient.interceptors.response.use(
+  (response) => {
+    console.log(`[API Response] ${response.status} ${response.config.url}`);
+    return response;
+  },
+  (error) => {
+    console.error('[API Response Error]', error);
+
+    // 에러 처리
+    if (error.response) {
+      const { status, data } = error.response;
+
+      switch (status) {
+        case 401:
+          // 인증 실패 - 로그인 페이지로 리다이렉트
+          console.error('인증 실패:', data.message);
+          // TODO: 로그인 페이지로 리다이렉트 로직 추가
+          break;
+        case 403:
+          // 권한 없음
+          console.error('권한 없음:', data.message);
+          break;
+        case 404:
+          console.error('리소스를 찾을 수 없음:', data.message);
+          break;
+        case 500:
+          console.error('서버 오류:', data.message);
+          break;
+        default:
+          console.error('API 오류:', data.message || '알 수 없는 오류');
+      }
+    } else if (error.request) {
+      // 네트워크 오류
+      console.error('네트워크 오류: 서버에 연결할 수 없습니다.');
+    }
+
+    return Promise.reject(error);
+  }
+);
+
+export default apiClient;
+
+// 공통 API 메서드들
+export const apiMethods = {
+  get: (url, config = {}) => apiClient.get(url, config),
+  post: (url, data = {}, config = {}) => apiClient.post(url, data, config),
+  put: (url, data = {}, config = {}) => apiClient.put(url, data, config),
+  patch: (url, data = {}, config = {}) => apiClient.patch(url, data, config),
+  delete: (url, config = {}) => apiClient.delete(url, config),
+};

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,9 +1,27 @@
+/**
+ * @fileoverview 공통 API 클라이언트 모듈
+ * @description axios 기반의 HTTP 클라이언트 설정 및 공통 API 메서드 제공
+ * @author 신동준
+ * @since 2025-09-17
+ * @version 1.0.0
+ */
+
 import axios from 'axios';
 
 // API 기본 설정
 const API_BASE_URL = 'http://localhost:9005/api';
 
-// Axios 인스턴스 생성
+/**
+ * @description axios 인스턴스 생성 및 기본 설정
+ * @author 신동준
+ * @since 2025-09-17
+ *
+ * 설정 항목:
+ * - baseURL: 백엔드 API 서버 기본 URL
+ * - timeout: 요청 타임아웃 (10초)
+ * - withCredentials: JWT 쿠키 전달을 위한 설정
+ * - headers: 기본 헤더 설정 (Content-Type: application/json)
+ */
 const apiClient = axios.create({
   baseURL: API_BASE_URL,
   timeout: 10000,
@@ -13,7 +31,15 @@ const apiClient = axios.create({
   },
 });
 
-// 요청 인터셉터
+/**
+ * @description 요청 인터셉터 설정
+ * @author 신동준
+ * @since 2025-09-17
+ *
+ * 기능:
+ * - 요청 전 로깅 (HTTP 메서드와 URL 출력)
+ * - 요청 에러 처리
+ */
 apiClient.interceptors.request.use(
   (config) => {
     // 요청 전 처리 (로딩 상태 등)
@@ -26,7 +52,20 @@ apiClient.interceptors.request.use(
   }
 );
 
-// 응답 인터셉터
+/**
+ * @description 응답 인터셉터 설정
+ * @author 신동준
+ * @since 2025-09-17
+ *
+ * 기능:
+ * - 응답 성공 시 로깅
+ * - HTTP 상태 코드별 에러 처리
+ *   - 401: 인증 실패 (로그인 페이지 리다이렉트 준비)
+ *   - 403: 권한 없음
+ *   - 404: 리소스를 찾을 수 없음
+ *   - 500: 서버 내부 오류
+ * - 네트워크 에러 처리
+ */
 apiClient.interceptors.response.use(
   (response) => {
     console.log(`[API Response] ${response.status} ${response.config.url}`);
@@ -67,9 +106,30 @@ apiClient.interceptors.response.use(
   }
 );
 
+/**
+ * @description 기본 axios 인스턴스 내보내기
+ * @author 신동준
+ * @since 2025-09-17
+ */
 export default apiClient;
 
-// 공통 API 메서드들
+/**
+ * @description 공통 API 메서드 객체
+ * @author 신동준
+ * @since 2025-09-17
+ *
+ * 제공 메서드:
+ * - get: GET 요청
+ * - post: POST 요청 (데이터 생성)
+ * - put: PUT 요청 (데이터 전체 수정)
+ * - patch: PATCH 요청 (데이터 부분 수정)
+ * - delete: DELETE 요청 (데이터 삭제)
+ *
+ * @param {string} url - API 엔드포인트 URL
+ * @param {Object} data - 요청 데이터 (POST, PUT, PATCH용)
+ * @param {Object} config - 추가 axios 설정 옵션
+ * @returns {Promise} axios 응답 Promise
+ */
 export const apiMethods = {
   get: (url, config = {}) => apiClient.get(url, config),
   post: (url, data = {}, config = {}) => apiClient.post(url, data, config),

--- a/src/services/scheduleApi.js
+++ b/src/services/scheduleApi.js
@@ -1,0 +1,113 @@
+import { apiMethods } from './api.js';
+
+// 일정 API 클라이언트
+export const scheduleApi = {
+  // 새 일정 생성
+  create: async (scheduleData) => {
+    const response = await apiMethods.post('/schedules', scheduleData);
+    return response.data;
+  },
+
+  // 특정 일정 조회
+  getById: async (scheduleId) => {
+    const response = await apiMethods.get(`/schedules/${scheduleId}`);
+    return response.data;
+  },
+
+  // 일정 수정
+  update: async (scheduleId, scheduleData) => {
+    const response = await apiMethods.put(`/schedules/${scheduleId}`, scheduleData);
+    return response.data;
+  },
+
+  // 일정 삭제
+  delete: async (scheduleId) => {
+    const response = await apiMethods.delete(`/schedules/${scheduleId}`);
+    return response.data;
+  },
+
+  // 일정 완료/미완료 토글
+  toggleComplete: async (scheduleId, isCompleted) => {
+    const response = await apiMethods.put(`/schedules/${scheduleId}/complete`, {
+      isCompleted
+    });
+    return response.data;
+  },
+
+  // 월별 일정 조회 (캘린더용)
+  getByMonth: async (year, month) => {
+    const response = await apiMethods.get(`/calendar?year=${year}&month=${month}`);
+    return response.data.schedules || [];
+  },
+
+  // 특정 날짜의 일정 조회
+  getByDate: async (date) => {
+    // date는 'YYYY-MM-DD' 형식
+    const [year, month] = date.split('-');
+    const monthData = await scheduleApi.getByMonth(year, month);
+    return monthData.filter(schedule => schedule.scheduleDate === date);
+  },
+};
+
+// 일정 데이터 변환 유틸리티
+export const scheduleUtils = {
+  // FullCalendar 이벤트 형식으로 변환
+  toFullCalendarEvent: (schedule) => ({
+    id: schedule.scheduleId,
+    title: schedule.title,
+    start: schedule.startTime
+      ? `${schedule.scheduleDate}T${schedule.startTime}`
+      : schedule.scheduleDate,
+    end: schedule.endTime
+      ? `${schedule.scheduleDate}T${schedule.endTime}`
+      : null,
+    allDay: !schedule.startTime && !schedule.endTime,
+    backgroundColor: schedule.isCompleted ? '#28a745' : '#007bff',
+    borderColor: schedule.isCompleted ? '#28a745' : '#007bff',
+    textColor: '#ffffff',
+    extendedProps: {
+      memo: schedule.memo,
+      location: schedule.location,
+      attendees: schedule.attendees,
+      isCompleted: schedule.isCompleted,
+    },
+  }),
+
+  // FullCalendar 이벤트 배열로 변환
+  toFullCalendarEvents: (schedules) => {
+    return schedules.map(schedule => scheduleUtils.toFullCalendarEvent(schedule));
+  },
+
+  // 폼 데이터 검증
+  validateScheduleData: (data) => {
+    const errors = {};
+
+    if (!data.title?.trim()) {
+      errors.title = '일정 제목을 입력해주세요.';
+    }
+
+    if (!data.scheduleDate) {
+      errors.scheduleDate = '일정 날짜를 선택해주세요.';
+    }
+
+    if (data.startTime && data.endTime && data.startTime >= data.endTime) {
+      errors.endTime = '종료 시간은 시작 시간보다 늦어야 합니다.';
+    }
+
+    return {
+      isValid: Object.keys(errors).length === 0,
+      errors,
+    };
+  },
+
+  // 기본 일정 데이터 생성
+  createDefaultSchedule: (date = null) => ({
+    title: '',
+    memo: '',
+    scheduleDate: date || new Date().toISOString().split('T')[0],
+    startTime: '',
+    endTime: '',
+    location: '',
+    attendees: '',
+  }),
+};

--- a/src/services/scheduleApi.js
+++ b/src/services/scheduleApi.js
@@ -1,32 +1,91 @@
+/**
+ * @fileoverview 일정 관리 API 클라이언트 모듈
+ * @description 일정 CRUD API 호출 및 FullCalendar 연동을 위한 데이터 변환 유틸리티 제공
+ * @author 신동준
+ * @since 2025-09-17
+ * @version 1.0.0
+ */
+
 import { apiMethods } from './api.js';
 
-// 일정 API 클라이언트
+/**
+ * @description 일정 관리 API 클라이언트 객체
+ * @author 신동준
+ * @since 2025-09-17
+ *
+ * 백엔드 API 엔드포인트:
+ * - POST /schedules - 일정 생성
+ * - GET /schedules/{scheduleId} - 특정 일정 조회
+ * - PUT /schedules/{scheduleId} - 일정 수정
+ * - DELETE /schedules/{scheduleId} - 일정 삭제
+ * - PUT /schedules/{scheduleId}/complete - 일정 완료/미완료 토글
+ * - GET /calendar?year={year}&month={month} - 월별 일정 조회
+ */
 export const scheduleApi = {
-  // 새 일정 생성
+  /**
+   * @description 새 일정 생성
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {Object} scheduleData - 일정 데이터
+   * @param {string} scheduleData.title - 일정 제목
+   * @param {string} scheduleData.memo - 일정 메모
+   * @param {string} scheduleData.scheduleDate - 일정 날짜 (YYYY-MM-DD)
+   * @param {string} scheduleData.startTime - 시작 시간 (HH:MM)
+   * @param {string} scheduleData.endTime - 종료 시간 (HH:MM)
+   * @param {string} scheduleData.location - 장소
+   * @param {string} scheduleData.attendees - 참여자
+   * @returns {Promise<Object>} 생성된 일정 데이터
+   */
   create: async (scheduleData) => {
     const response = await apiMethods.post('/schedules', scheduleData);
     return response.data;
   },
 
-  // 특정 일정 조회
+  /**
+   * @description 특정 일정 조회
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {number} scheduleId - 일정 ID
+   * @returns {Promise<Object>} 일정 데이터
+   */
   getById: async (scheduleId) => {
     const response = await apiMethods.get(`/schedules/${scheduleId}`);
     return response.data;
   },
 
-  // 일정 수정
+  /**
+   * @description 일정 수정
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {number} scheduleId - 일정 ID
+   * @param {Object} scheduleData - 수정할 일정 데이터
+   * @returns {Promise<Object>} 수정된 일정 데이터
+   */
   update: async (scheduleId, scheduleData) => {
     const response = await apiMethods.put(`/schedules/${scheduleId}`, scheduleData);
     return response.data;
   },
 
-  // 일정 삭제
+  /**
+   * @description 일정 삭제
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {number} scheduleId - 일정 ID
+   * @returns {Promise<Object>} 삭제 결과
+   */
   delete: async (scheduleId) => {
     const response = await apiMethods.delete(`/schedules/${scheduleId}`);
     return response.data;
   },
 
-  // 일정 완료/미완료 토글
+  /**
+   * @description 일정 완료/미완료 상태 토글
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {number} scheduleId - 일정 ID
+   * @param {boolean} isCompleted - 완료 상태 (true: 완료, false: 미완료)
+   * @returns {Promise<Object>} 업데이트된 일정 데이터
+   */
   toggleComplete: async (scheduleId, isCompleted) => {
     const response = await apiMethods.put(`/schedules/${scheduleId}/complete`, {
       isCompleted
@@ -34,13 +93,26 @@ export const scheduleApi = {
     return response.data;
   },
 
-  // 월별 일정 조회 (캘린더용)
+  /**
+   * @description 월별 일정 조회 (캘린더용)
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {number} year - 조회할 연도
+   * @param {number} month - 조회할 월 (1-12)
+   * @returns {Promise<Array>} 해당 월의 일정 배열
+   */
   getByMonth: async (year, month) => {
     const response = await apiMethods.get(`/calendar?year=${year}&month=${month}`);
     return response.data.schedules || [];
   },
 
-  // 특정 날짜의 일정 조회
+  /**
+   * @description 특정 날짜의 일정 조회
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {string} date - 조회할 날짜 (YYYY-MM-DD 형식)
+   * @returns {Promise<Array>} 해당 날짜의 일정 배열
+   */
   getByDate: async (date) => {
     // date는 'YYYY-MM-DD' 형식
     const [year, month] = date.split('-');
@@ -49,9 +121,30 @@ export const scheduleApi = {
   },
 };
 
-// 일정 데이터 변환 유틸리티
+/**
+ * @description 일정 데이터 변환 및 검증 유틸리티 객체
+ * @author 신동준
+ * @since 2025-09-17
+ *
+ * 주요 기능:
+ * - FullCalendar 이벤트 형식으로 데이터 변환
+ * - 일정 데이터 유효성 검증
+ * - 기본 일정 데이터 생성
+ */
 export const scheduleUtils = {
-  // FullCalendar 이벤트 형식으로 변환
+  /**
+   * @description 일정 데이터를 FullCalendar 이벤트 형식으로 변환
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {Object} schedule - 일정 데이터
+   * @param {number} schedule.scheduleId - 일정 ID
+   * @param {string} schedule.title - 일정 제목
+   * @param {string} schedule.scheduleDate - 일정 날짜
+   * @param {string} schedule.startTime - 시작 시간 (선택사항)
+   * @param {string} schedule.endTime - 종료 시간 (선택사항)
+   * @param {boolean} schedule.isCompleted - 완료 상태
+   * @returns {Object} FullCalendar 이벤트 객체
+   */
   toFullCalendarEvent: (schedule) => ({
     id: schedule.scheduleId,
     title: schedule.title,
@@ -73,12 +166,26 @@ export const scheduleUtils = {
     },
   }),
 
-  // FullCalendar 이벤트 배열로 변환
+  /**
+   * @description 일정 배열을 FullCalendar 이벤트 배열로 변환
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {Array} schedules - 일정 데이터 배열
+   * @returns {Array} FullCalendar 이벤트 객체 배열
+   */
   toFullCalendarEvents: (schedules) => {
     return schedules.map(schedule => scheduleUtils.toFullCalendarEvent(schedule));
   },
 
-  // 폼 데이터 검증
+  /**
+   * @description 일정 데이터 유효성 검증
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {Object} data - 검증할 일정 데이터
+   * @returns {Object} 검증 결과 객체
+   * @returns {boolean} returns.isValid - 유효성 검증 통과 여부
+   * @returns {Object} returns.errors - 에러 메시지 객체 (필드명: 에러메시지)
+   */
   validateScheduleData: (data) => {
     const errors = {};
 
@@ -100,7 +207,13 @@ export const scheduleUtils = {
     };
   },
 
-  // 기본 일정 데이터 생성
+  /**
+   * @description 기본 일정 데이터 객체 생성
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {string|null} date - 기본 날짜 (YYYY-MM-DD 형식, null이면 오늘 날짜)
+   * @returns {Object} 기본 일정 데이터 객체
+   */
   createDefaultSchedule: (date = null) => ({
     title: '',
     memo: '',

--- a/src/store/scheduleStore.js
+++ b/src/store/scheduleStore.js
@@ -1,0 +1,244 @@
+/**
+ * @fileoverview 일정 관리 전역 상태 모듈
+ * @description Zustand 기반의 일정 관리 전역 상태 및 모달 상태 관리
+ * @author 신동준
+ * @since 2025-09-17
+ * @version 1.0.0
+ */
+
+import { create } from 'zustand';
+
+/**
+ * @description 일정 관리 전역 상태 스토어
+ * @author 신동준
+ * @since 2025-09-17
+ *
+ * 주요 기능:
+ * - 일정 목록 상태 관리
+ * - 선택된 날짜/일정 상태 관리
+ * - 모달 상태 관리 (등록/수정/상세보기)
+ * - 로딩/에러 상태 관리
+ * - 일정 CRUD 액션 함수들
+ *
+ * @returns {Object} 일정 관리 스토어 객체
+ */
+export const useScheduleStore = create((set, get) => ({
+  /**
+   * @description 전체 일정 목록
+   * @type {Array<Object>}
+   */
+  schedules: [],
+
+  /**
+   * @description 현재 선택된 날짜 (YYYY-MM-DD 형식)
+   * @type {string|null}
+   */
+  selectedDate: null,
+
+  /**
+   * @description 현재 선택된 일정 객체
+   * @type {Object|null}
+   */
+  selectedSchedule: null,
+
+  /**
+   * @description 로딩 상태
+   * @type {boolean}
+   */
+  loading: false,
+
+  /**
+   * @description 에러 메시지
+   * @type {string|null}
+   */
+  error: null,
+
+  /**
+   * @description 일정 모달 열림/닫힘 상태
+   * @type {boolean}
+   */
+  isScheduleModalOpen: false,
+
+  /**
+   * @description 일정 모달 타입 ('create' | 'edit')
+   * @type {string|null}
+   */
+  scheduleModalType: null,
+
+  /**
+   * @description 일정 상세보기 모달 열림/닫힘 상태
+   * @type {boolean}
+   */
+  isScheduleDetailOpen: false,
+
+  /**
+   * @description 일정 목록 설정 함수
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {Array<Object>} schedules - 설정할 일정 배열
+   */
+  setSchedules: (schedules) => set({ schedules }),
+
+  /**
+   * @description 새 일정 추가 함수
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {Object} schedule - 추가할 일정 객체
+   */
+  addSchedule: (schedule) => set((state) => ({
+    schedules: [...state.schedules, schedule]
+  })),
+
+  /**
+   * @description 기존 일정 업데이트 함수
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {number} scheduleId - 업데이트할 일정 ID
+   * @param {Object} updatedSchedule - 업데이트된 일정 객체
+   */
+  updateSchedule: (scheduleId, updatedSchedule) => set((state) => ({
+    schedules: state.schedules.map(schedule =>
+      schedule.scheduleId === scheduleId ? updatedSchedule : schedule
+    ),
+    selectedSchedule: state.selectedSchedule?.scheduleId === scheduleId
+      ? updatedSchedule
+      : state.selectedSchedule
+  })),
+
+  /**
+   * @description 일정 삭제 함수
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {number} scheduleId - 삭제할 일정 ID
+   */
+  removeSchedule: (scheduleId) => set((state) => ({
+    schedules: state.schedules.filter(schedule => schedule.scheduleId !== scheduleId),
+    selectedSchedule: state.selectedSchedule?.scheduleId === scheduleId
+      ? null
+      : state.selectedSchedule
+  })),
+
+  /**
+   * @description 선택된 날짜 설정 함수
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {string} date - 선택할 날짜 (YYYY-MM-DD 형식)
+   */
+  setSelectedDate: (date) => set({ selectedDate: date }),
+
+  /**
+   * @description 선택된 일정 설정 함수
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {Object} schedule - 선택할 일정 객체
+   */
+  setSelectedSchedule: (schedule) => set({ selectedSchedule: schedule }),
+
+  /**
+   * @description 선택된 일정 초기화 함수
+   * @author 신동준
+   * @since 2025-09-17
+   */
+  clearSelectedSchedule: () => set({ selectedSchedule: null }),
+
+  /**
+   * @description 특정 날짜의 일정들 조회 함수
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {string} date - 조회할 날짜 (YYYY-MM-DD 형식)
+   * @returns {Array<Object>} 해당 날짜의 일정 배열
+   */
+  getSchedulesByDate: (date) => {
+    const { schedules } = get();
+    return schedules.filter(schedule => schedule.scheduleDate === date);
+  },
+
+  /**
+   * @description 로딩 상태 설정 함수
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {boolean} loading - 로딩 상태
+   */
+  setLoading: (loading) => set({ loading }),
+
+  /**
+   * @description 에러 메시지 설정 함수
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {string} error - 에러 메시지
+   */
+  setError: (error) => set({ error }),
+
+  /**
+   * @description 에러 상태 초기화 함수
+   * @author 신동준
+   * @since 2025-09-17
+   */
+  clearError: () => set({ error: null }),
+
+  /**
+   * @description 일정 모달 열기 함수
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {string} type - 모달 타입 ('create' | 'edit')
+   * @param {Object|null} schedule - 편집할 일정 객체 (edit 모드일 때)
+   */
+  openScheduleModal: (type = 'create', schedule = null) => set({
+    isScheduleModalOpen: true,
+    scheduleModalType: type,
+    selectedSchedule: schedule
+  }),
+
+  /**
+   * @description 일정 모달 닫기 함수
+   * @author 신동준
+   * @since 2025-09-17
+   */
+  closeScheduleModal: () => set({
+    isScheduleModalOpen: false,
+    scheduleModalType: null,
+    selectedSchedule: null
+  }),
+
+  /**
+   * @description 일정 상세보기 모달 열기 함수
+   * @author 신동준
+   * @since 2025-09-17
+   * @param {Object} schedule - 상세보기할 일정 객체
+   */
+  openScheduleDetail: (schedule) => set({
+    isScheduleDetailOpen: true,
+    selectedSchedule: schedule
+  }),
+
+  /**
+   * @description 일정 상세보기 모달 닫기 함수
+   * @author 신동준
+   * @since 2025-09-17
+   */
+  closeScheduleDetail: () => set({
+    isScheduleDetailOpen: false,
+    selectedSchedule: null
+  }),
+
+  /**
+   * @description 스토어 상태 전체 초기화 함수
+   * @author 신동준
+   * @since 2025-09-17
+   *
+   * 사용 시나리오:
+   * - 로그아웃 시
+   * - 컴포넌트 언마운트 시
+   * - 데이터 리셋이 필요한 경우
+   */
+  resetScheduleStore: () => set({
+    schedules: [],
+    selectedDate: null,
+    selectedSchedule: null,
+    loading: false,
+    error: null,
+    isScheduleModalOpen: false,
+    scheduleModalType: null,
+    isScheduleDetailOpen: false,
+  }),
+}));


### PR DESCRIPTION
## PR 유형 (Type of PR)
- [x] 기능 (Feature)
- [ ] 버그 수정 (Bugfix)
- [ ] 기능 개선 (Enhancement)
- [ ] 리팩토링 (Refactoring)
- [ ] 문서 (Docs)
- [ ] 기타 (Chore)

---

## PR 요약 (PR Summary)

백엔드 일정 관리 API 연동을 위한 프론트엔드 기반 구조를 구현합니다.
주요 작업 내용은 다음과 같습니다:
- **API 클라이언트**: `axios`를 사용한 공통 API 클라이언트 및 일정 전용 API 클라이언트 구현
- **상태 관리**: `Zustand`를 사용한 전역 일정 상태 및 `React Custom Hook`을 사용한 비즈니스 로직 구현
- **유틸리티**: FullCalendar 연동을 위한 데이터 변환 및 유효성 검증 유틸리티 구현

---

## 관련 이슈 (Related Issue)

- Closes #10 

---

## 변경 사항 (Changes)

### 1. 공통 API 클라이언트 (`src/services/api.js`)
- `axios` 인스턴스를 생성하고 기본 설정(baseURL, timeout, withCredentials)을 적용했습니다.
- 요청/응답 인터셉터를 구현하여 모든 API 통신에 대한 로깅 및 중앙 집중식 에러 처리가 가능하도록 했습니다.
- 로그인 기능 구현 전 테스트를 위해, 요청 인터셉터에 임시 인증 토큰을 추가할 수 있는 로직을 주석 처리하여 포함했습니다.

### 2. 일정 API 클라이언트 (`src/services/scheduleApi.js`)
- 일정 CRUD(`create`, `getById`, `update`, `delete`) 및 완료 토글(`toggleComplete`) API 호출 함수를 구현했습니다.
- 월별/날짜별 일정 조회를 위한 `getByMonth`, `getByDate` 함수를 구현했습니다.
- 백엔드 데이터를 FullCalendar 이벤트 형식으로 변환하는 `toFullCalendarEvent` 유틸리티 함수를 추가했습니다.
- 폼 데이터 유효성을 검증하는 `validateScheduleData` 유틸리티 함수를 추가했습니다.

### 3. 일정 전역 상태 관리 (`src/store/scheduleStore.js`)
- `Zustand`를 사용하여 일정 목록, 선택된 날짜/일정, 로딩/에러 상태를 관리하는 전역 스토어를 구현했습니다.
- 일정 등록/수정/상세보기를 위한 모달(`isScheduleModalOpen`, `scheduleModalType` 등) 상태와 제어 함수를 추가했습니다.

### 4. 일정 커스텀 훅 (`src/hooks/schedule/useSchedule.js`)
- API 호출과 상태 관리를 결합하여 일정 CRUD 비즈니스 로직을 처리하는 `useSchedule` 훅을 구현했습니다.
- `withLoading` 고차 함수를 통해 API 호출 시 로딩 및 에러 상태를 자동으로 관리하도록 구현했습니다.
- 컴포넌트에서 비즈니스 로직을 분리하여 재사용성과 유지보수성을 높였습니다.

---

## 스크린샷 (Screenshots) (Optional)

이번 PR은 API 클라이언트 및 상태 관리 로직 구현이므로 UI 변경 사항은 없습니다.

---

## 테스트 방법 (Test Steps)

1. `npm run dev`로 개발 서버를 실행합니다.
2. `src/App.jsx`에 `<ConsoleTestComponent />`를 임시로 추가합니다.
3. 브라우저 개발자 도구 콘솔을 엽니다.
4. `scheduleTest` 객체를 사용하여 아래 함수들을 실행하고, 네트워크 탭과 콘솔 로그를 통해 API 호출 및 상태 변경이 정상적으로 이루어지는지 확인합니다.
   - `scheduleTest.api.createSampleSchedule()`: 샘플 일정 생성
   - `scheduleTest.api.testGetByMonth(2025, 9)`: 2025년 9월 일정 조회
   - `scheduleTest.store.getState()`: 현재 Zustand 스토어 상태 확인
 
### 프론트엔드 로그인 기능 추가 후 인증된 사용자로 테스트 가능한 콘솔 함수들

<img width="668" height="555" alt="로그인 기능 추가 후 테스트 예정" src="https://github.com/user-attachments/assets/dd739148-e837-45a3-8149-1a09818fdd69" />




---

## 셀프 체크리스트 (Self-Checklist)

- [x] 제목 규칙을 지켰습니다.
- [x] 관련 이슈를 연결했습니다.
- [x] 로컬에서 충분히 테스트했습니다.
- [x] `dev` 브랜치를 Pull하여 최신 코드를 반영했습니다.
- [ ] CI/CD 파이프라인이 통과했습니다.

---

## 리뷰어에게 (To Reviewers)

- `useSchedule` 훅과 `useScheduleStore`의 역할 분리가 적절한지 검토 부탁드립니다. 훅은 API 연동과 비동기 로직을, 스토어는 전역 상태 저장을 담당하도록 설계했습니다.
- 향후 FullCalendar와 연동 시 데이터 흐름에 문제가 없을지 구조적인 관점에서 검토해주시면 감사하겠습니다.
